### PR TITLE
Group StackBarChart & Bar

### DIFF
--- a/src/bar-chart/bar-chart-grouped.js
+++ b/src/bar-chart/bar-chart-grouped.js
@@ -145,8 +145,8 @@ class GroupedBarChart extends BarChart {
         const extent = array.extent([ ...dataExtent, gridMax, gridMin ])
 
         const {
-            yMin = extent[ 0 ],
-            yMax = extent[ 1 ],
+            yMin = extent[0],
+            yMax = extent[1],
         } = this.props
 
         return [ yMin, yMax ]
@@ -154,7 +154,7 @@ class GroupedBarChart extends BarChart {
 
     calcIndexes() {
         const { data } = this.props
-        return data[ 0 ].data.map((_, index) => index)
+        return data[0].data.map((_, index) => index)
     }
 }
 

--- a/src/stacked-bar-chart/index.js
+++ b/src/stacked-bar-chart/index.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import StackedBarChart from './stacked-bar-chart'
+import StackedBarChartGrouped from './stacked-bar-grouped'
+
+const StackedBarChartGate = props => {
+    const { data } = props
+
+    if (data[0].hasOwnProperty('data')) {
+        return <StackedBarChartGrouped { ...props } />
+    }
+
+    return <StackedBarChart { ...props } />
+}
+
+export default StackedBarChartGate

--- a/src/stacked-bar-chart/stacked-bar-chart.js
+++ b/src/stacked-bar-chart/stacked-bar-chart.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'
 import { View } from 'react-native'
 import Svg from 'react-native-svg'
-import Path from './animated-path'
+import Path from '../animated-path'
 
 class BarChart extends PureComponent {
     static extractDataPoints(data, keys, order = shape.stackOrderNone, offset = shape.stackOffsetNone) {
@@ -100,7 +100,7 @@ class BarChart extends PureComponent {
             )
         }
 
-        return array.merge(
+        const ret = array.merge(
             series.map((serie, keyIndex) => {
                 return serie.map((entry, entryIndex) => {
                     const path = shape
@@ -118,28 +118,44 @@ class BarChart extends PureComponent {
                 })
             })
         )
+
+        console.log('TEST', ret)
+        return ret
     }
 
-    calcIndexes() {
-        const { data } = this.props
-        return data.map((_, index) => index)
+    calcExtent(values) {
+        const {
+            gridMax,
+            gridMin,
+        } = this.props
+
+        return array.extent([ ...values, gridMin, gridMax ])
+    }
+
+    calcIndexes(values) {
+        return values.map((_, index) => index)
+    }
+
+    getSeries() {
+        const { data, keys, offset, order, valueAccessor } = this.props
+
+        return shape
+            .stack()
+            .keys(keys)
+            .value((item, key) => valueAccessor({ item, key }))
+            .order(order)
+            .offset(offset)(data)
     }
 
     render() {
         const {
             data,
-            keys,
-            order,
-            offset,
             animate,
             animationDuration,
             style,
             numberOfTicks,
-            gridMax,
-            gridMin,
             children,
             horizontal,
-            valueAccessor,
         } = this.props
 
         const { height, width } = this.state
@@ -148,18 +164,13 @@ class BarChart extends PureComponent {
             return <View style={ style } />
         }
 
-        const series = shape
-            .stack()
-            .keys(keys)
-            .value((item, key) => valueAccessor({ item, key }))
-            .order(order)
-            .offset(offset)(data)
+        const series = this.getSeries()
 
         //double merge arrays to extract just the values
         const values = array.merge(array.merge(series))
-        const indexes = values.map((_, index) => index)
+        const indexes = this.calcIndexes(values)
 
-        const extent = array.extent([ ...values, gridMin, gridMax ])
+        const extent = this.calcExtent(values)
         const ticks = array.ticks(extent[0], extent[1], numberOfTicks)
 
         const xDomain = horizontal ? extent : indexes
@@ -197,7 +208,7 @@ class BarChart extends PureComponent {
                                 areas.map((bar, index) => {
                                     const keyIndex = index % data.length
                                     const key = `${keyIndex}-${bar.key}`
-                                    const { svg } = data[ keyIndex ][ bar.key ]
+                                    const { svg } = data[keyIndex][bar.key]
 
                                     return (
                                         <Path

--- a/src/stacked-bar-chart/stacked-bar-chart.js
+++ b/src/stacked-bar-chart/stacked-bar-chart.js
@@ -100,7 +100,7 @@ class BarChart extends PureComponent {
             )
         }
 
-        const ret = array.merge(
+        return array.merge(
             series.map((serie, keyIndex) => {
                 return serie.map((entry, entryIndex) => {
                     const path = shape
@@ -118,9 +118,6 @@ class BarChart extends PureComponent {
                 })
             })
         )
-
-        console.log('TEST', ret)
-        return ret
     }
 
     calcExtent(values) {

--- a/src/stacked-bar-chart/stacked-bar-grouped.js
+++ b/src/stacked-bar-chart/stacked-bar-grouped.js
@@ -30,9 +30,6 @@ class StackedBarGrouped extends PureComponent {
                 .range([ left, width - right ])
         }
 
-        // use index as domain identifier instead of value since
-        // domain must be same length as number of bars
-        // same value can occur at several places in data
         return scale
             .scaleBand()
             .domain(domain)
@@ -133,6 +130,7 @@ class StackedBarGrouped extends PureComponent {
     calcIndexes() {
         const { data } = this.props
 
+        // Must return an array with indexes for the number of groups to be shown
         return data[0].data.map((_, index) => index)
     }
 

--- a/src/stacked-bar-chart/stacked-bar-grouped.js
+++ b/src/stacked-bar-chart/stacked-bar-grouped.js
@@ -1,0 +1,198 @@
+import React from 'react'
+import { View } from 'react-native'
+import PropTypes from 'prop-types'
+import Svg from 'react-native-svg'
+import * as array from 'd3-array'
+import * as shape from 'd3-shape'
+import Path from '../animated-path'
+import BarChart from './stacked-bar-chart'
+
+class StackedBarGrouped extends BarChart {
+    calcAreas(x, y, series) {
+        const { horizontal, colors, keys, data } = this.props
+        let areas
+        let barWidth = x.bandwidth() / data.length
+
+        if (horizontal) {
+            barWidth = y.bandwidth() / data.length
+
+            areas = series.map((stack, stackIndex) => {
+                return stack.map((serie, keyIndex) => {
+                    return serie.map((entry, entryIndex) => {
+                        const path = shape
+                            .area()
+                            .x0(d => x(d[0]))
+                            .x1(d => x(d[1]))
+                            .y((d, _index) => (_index === 0 ?
+                                y(entryIndex) + (barWidth * stackIndex) :
+                                y(entryIndex) + barWidth + (barWidth * stackIndex)))
+                            .defined(d => !isNaN(d[0]) && !isNaN(d[1]))([ entry, entry ])
+
+                        return {
+                            path,
+                            color: colors[stackIndex][keyIndex],
+                            key: keys[stackIndex][keyIndex],
+                        }
+                    })
+                })
+            })
+        } else {
+            areas = series.map((stack, stackIndex) => {
+                return stack.map((serie, keyIndex) => {
+                    return serie.map((entry, entryIndex) => {
+                        const path = shape
+                            .area()
+                            .y0(d => y(d[0]))
+                            .y1(d => y(d[1]))
+                            .x((d, _index) => (_index === 0 ?
+                                x(entryIndex) + (barWidth * stackIndex) :
+                                x(entryIndex) + barWidth + (barWidth * stackIndex)))
+                            .defined(d => !isNaN(d[0]) && !isNaN(d[1]))([ entry, entry ])
+
+                        return {
+                            path,
+                            color: colors[stackIndex][keyIndex],
+                            key: keys[stackIndex][keyIndex],
+                        }
+                    })
+                })
+            })
+        }
+
+        return array.merge(areas)
+    }
+
+    calcExtent(values) {
+        const {
+            gridMax,
+            gridMin,
+        } = this.props
+
+        // One more merge for stacked groups
+        const mergedValues = array.merge(values)
+
+        return array.extent([ ...mergedValues, gridMin, gridMax ])
+    }
+
+    calcIndexes(values) {
+        // One more merge for stacked groups
+        const mergedValues = array.merge(values)
+
+        return mergedValues.map((_, index) => index)
+    }
+
+    getSeries() {
+        const { data, keys, offset, order, valueAccessor } = this.props
+
+        return data.map((obj, index) => shape
+            .stack()
+            .keys(keys[index])
+            .value((item, key) => valueAccessor({ item, key }))
+            .order(order)
+            .offset(offset)(obj.data))
+    }
+
+    render() {
+        const {
+            data,
+            animate,
+            animationDuration,
+            style,
+            numberOfTicks,
+            children,
+            horizontal,
+        } = this.props
+
+        const { height, width } = this.state
+
+        if (data.length === 0) {
+            return <View style={ style } />
+        }
+
+        const series = this.getSeries()
+
+        //double merge arrays to extract just the values
+        const values = array.merge(array.merge(series))
+        const indexes = this.calcIndexes(values)
+
+        const extent = this.calcExtent(values)
+        const ticks = array.ticks(extent[0], extent[1], numberOfTicks)
+
+        const xDomain = horizontal ? extent : indexes
+        const yDomain = horizontal ? indexes : extent
+
+        const x = this.calcXScale(xDomain)
+        const y = this.calcYScale(yDomain)
+
+        const stacks = this.calcAreas(x, y, series)
+
+        const extraProps = {
+            x,
+            y,
+            width,
+            height,
+            ticks,
+            data,
+        }
+
+        return (
+            <View style={ style }>
+                <View style={{ flex: 1 }} onLayout={ event => this._onLayout(event) }>
+                    {
+                        height > 0 && width > 0 &&
+                        <Svg style={{ height, width }}>
+                            {
+                                React.Children.map(children, child => {
+                                    if (child && child.props.belowChart) {
+                                        return React.cloneElement(child, extraProps)
+                                    }
+                                    return null
+                                })
+                            }
+                            {
+                                stacks.map((areas, indexStack) => {
+                                    const areaIndex = indexStack % data.length
+
+                                    return areas.map((bar, indexArea) => {
+                                        const keyIndex = indexArea % data[areaIndex].data.length
+                                        const key = `${areaIndex}-${keyIndex}-${bar.key}`
+
+                                        const { svg } = data[areaIndex].data[keyIndex][bar.key]
+
+                                        return (
+                                            <Path
+                                                key={ key }
+                                                fill={ bar.color }
+                                                { ...svg }
+                                                d={ bar.path }
+                                                animate={ animate }
+                                                animationDuration={ animationDuration }
+                                            />
+                                        )
+                                    })
+                                })
+
+                            }
+                            {
+                                React.Children.map(children, child => {
+                                    if (child && !child.props.belowChart) {
+                                        return React.cloneElement(child, extraProps)
+                                    }
+                                    return null
+                                })
+                            }
+                        </Svg>
+                    }
+                </View>
+            </View>
+        )
+    }
+}
+
+StackedBarGrouped.propTypes = {
+    ...BarChart.propTypes,
+    keys: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired,
+    colors: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired,
+}
+
+export default StackedBarGrouped

--- a/storybook/stories/bar-stack/grouped.js
+++ b/storybook/stories/bar-stack/grouped.js
@@ -106,7 +106,7 @@ class StackedBarChartExample extends React.PureComponent {
                         bananas: 480,
                         cherries: 640,
                         dates: 400,
-                        oranges: 200,
+                        oranges: 2500,
                     }],
             },
         ]

--- a/storybook/stories/bar-stack/grouped.js
+++ b/storybook/stories/bar-stack/grouped.js
@@ -1,0 +1,132 @@
+import React from 'react'
+import { StackedBarChart, Grid } from 'react-native-svg-charts'
+
+class StackedBarChartExample extends React.PureComponent {
+    render() {
+        const data = [
+            {
+                data: [
+                    {
+                        month: new Date(2015, 0, 1),
+                        apples: 3840,
+                        bananas: 1920,
+                        cherries: 960,
+                        dates: 400,
+                        oranges: 400,
+                    },
+                    {
+                        month: new Date(2015, 1, 1),
+                        apples: 1600,
+                        bananas: 1440,
+                        cherries: 960,
+                        dates: 400,
+                        oranges: 600,
+                    },
+                    {
+                        month: new Date(2015, 2, 1),
+                        apples: 640,
+                        bananas: 960,
+                        cherries: 3640,
+                        dates: 400,
+                        oranges: 800,
+                    },
+                    {
+                        month: new Date(2015, 3, 1),
+                        apples: 3320,
+                        bananas: 480,
+                        cherries: 640,
+                        dates: 400,
+                        oranges: 200,
+                    }],
+            },
+            {
+                data: [
+                    {
+                        month: new Date(2015, 0, 1),
+                        apples: 3840,
+                        bananas: 1920,
+                        cherries: 960,
+                        dates: 400,
+                        oranges: 400,
+                    },
+                    {
+                        month: new Date(2015, 1, 1),
+                        apples: 1600,
+                        bananas: 1440,
+                        cherries: 960,
+                        dates: 400,
+                        oranges: 600,
+                    },
+                    {
+                        month: new Date(2015, 2, 1),
+                        apples: 640,
+                        bananas: 960,
+                        cherries: 3640,
+                        dates: 400,
+                        oranges: 800,
+                    },
+                    {
+                        month: new Date(2015, 3, 1),
+                        apples: 3320,
+                        bananas: 480,
+                        cherries: 640,
+                        dates: 400,
+                        oranges: 200,
+                    }],
+            },
+            {
+                data: [
+                    {
+                        month: new Date(2015, 0, 1),
+                        apples: 3840,
+                        bananas: 1920,
+                        cherries: 960,
+                        dates: 400,
+                        oranges: 400,
+                    },
+                    {
+                        month: new Date(2015, 1, 1),
+                        apples: 1600,
+                        bananas: 1440,
+                        cherries: 960,
+                        dates: 400,
+                        oranges: 600,
+                    },
+                    {
+                        month: new Date(2015, 2, 1),
+                        apples: 640,
+                        bananas: 960,
+                        cherries: 3640,
+                        dates: 400,
+                        oranges: 800,
+                    },
+                    {
+                        month: new Date(2015, 3, 1),
+                        apples: 3320,
+                        bananas: 480,
+                        cherries: 640,
+                        dates: 400,
+                        oranges: 200,
+                    }],
+            },
+        ]
+
+        const colors = [[ '#8800cc', '#aa00ff' ], [ '#dd99ff', '#cc66ff' ], [ '#eeccff' ]]
+        const keys = [[ 'apples', 'bananas' ], [ 'cherries', 'dates' ], [ 'oranges' ]]
+
+        return (
+            <StackedBarChart
+                style={{ height: 200 }}
+                keys={ keys }
+                colors={ colors }
+                data={ data }
+                showGrid={ false }
+                contentInset={{ top: 30, bottom: 30 }}
+            >
+                <Grid />
+            </StackedBarChart >
+        )
+    }
+}
+
+export default StackedBarChartExample

--- a/storybook/stories/bar-stack/horizontal-grouped.js
+++ b/storybook/stories/bar-stack/horizontal-grouped.js
@@ -1,0 +1,133 @@
+import React from 'react'
+import { StackedBarChart, Grid } from 'react-native-svg-charts'
+
+class StackedBarChartExample extends React.PureComponent {
+    render() {
+        const data = [
+            {
+                data: [
+                    {
+                        month: new Date(2015, 0, 1),
+                        apples: 3840,
+                        bananas: 1920,
+                        cherries: 960,
+                        dates: 1240,
+                        oranges: 4780,
+                    },
+                    {
+                        month: new Date(2015, 1, 1),
+                        apples: 1600,
+                        bananas: 1440,
+                        cherries: 960,
+                        dates: 3240,
+                        oranges: 3300,
+                    },
+                    {
+                        month: new Date(2015, 2, 1),
+                        apples: 640,
+                        bananas: 960,
+                        cherries: 3640,
+                        dates: 1900,
+                        oranges: 800,
+                    },
+                    {
+                        month: new Date(2015, 3, 1),
+                        apples: 3320,
+                        bananas: 480,
+                        cherries: 640,
+                        dates: 650,
+                        oranges: 2000,
+                    }],
+            },
+            {
+                data: [
+                    {
+                        month: new Date(2015, 0, 1),
+                        apples: 3840,
+                        bananas: 1920,
+                        cherries: 960,
+                        dates: 1240,
+                        oranges: 4780,
+                    },
+                    {
+                        month: new Date(2015, 1, 1),
+                        apples: 1600,
+                        bananas: 1440,
+                        cherries: 960,
+                        dates: 3240,
+                        oranges: 3300,
+                    },
+                    {
+                        month: new Date(2015, 2, 1),
+                        apples: 640,
+                        bananas: 960,
+                        cherries: 3640,
+                        dates: 1900,
+                        oranges: 800,
+                    },
+                    {
+                        month: new Date(2015, 3, 1),
+                        apples: 3320,
+                        bananas: 480,
+                        cherries: 640,
+                        dates: 650,
+                        oranges: 2000,
+                    }],
+            },
+            {
+                data: [
+                    {
+                        month: new Date(2015, 0, 1),
+                        apples: 3840,
+                        bananas: 1920,
+                        cherries: 960,
+                        dates: 1240,
+                        oranges: 4780,
+                    },
+                    {
+                        month: new Date(2015, 1, 1),
+                        apples: 1600,
+                        bananas: 1440,
+                        cherries: 960,
+                        dates: 3240,
+                        oranges: 3300,
+                    },
+                    {
+                        month: new Date(2015, 2, 1),
+                        apples: 640,
+                        bananas: 960,
+                        cherries: 3640,
+                        dates: 1900,
+                        oranges: 800,
+                    },
+                    {
+                        month: new Date(2015, 3, 1),
+                        apples: 3320,
+                        bananas: 480,
+                        cherries: 640,
+                        dates: 650,
+                        oranges: 2000,
+                    }],
+            },
+        ]
+
+        const colors = [[ '#8800cc', '#aa00ff', '#dd99ff' ], [ '#cc66ff' ], [ '#eeccff' ]]
+        const keys = [[ 'apples', 'cherries', 'bananas' ], [ 'dates' ], [ 'oranges' ]]
+
+        return (
+            <StackedBarChart
+                style={{ height: 200 }}
+                keys={ keys }
+                colors={ colors }
+                data={ data }
+                showGrid={ false }
+                contentInset={{ top: 30, bottom: 30 }}
+                horizontal
+            >
+                <Grid direction={ Grid.Direction.VERTICAL } />
+            </StackedBarChart >
+        )
+    }
+}
+
+export default StackedBarChartExample

--- a/storybook/stories/bar-stack/index.js
+++ b/storybook/stories/bar-stack/index.js
@@ -4,10 +4,12 @@ import { storiesOf } from '@storybook/react-native'
 import Standard from './standard'
 import Horizontal from './horizontal'
 import WithOnPress from './with-on-press'
+import Grouped from './grouped'
 import ShowcaseCard from '../showcase-card'
 
 storiesOf('BarStack', module)
-    .addDecorator(getStory => <ShowcaseCard>{ getStory() }</ShowcaseCard>)
-    .add('Standard', () => <Standard/>)
-    .add('Horizontal', () => <Horizontal/>)
-    .add('With onPress', () => <WithOnPress/>)
+    .addDecorator(getStory => <ShowcaseCard>{getStory()}</ShowcaseCard>)
+    .add('Standard', () => <Standard />)
+    .add('Horizontal', () => <Horizontal />)
+    .add('With onPress', () => <WithOnPress />)
+    .add('Grouped', () => <Grouped />)

--- a/storybook/stories/bar-stack/index.js
+++ b/storybook/stories/bar-stack/index.js
@@ -5,6 +5,7 @@ import Standard from './standard'
 import Horizontal from './horizontal'
 import WithOnPress from './with-on-press'
 import Grouped from './grouped'
+import HorizontalGrouped from './horizontal-grouped'
 import ShowcaseCard from '../showcase-card'
 
 storiesOf('BarStack', module)
@@ -13,3 +14,4 @@ storiesOf('BarStack', module)
     .add('Horizontal', () => <Horizontal />)
     .add('With onPress', () => <WithOnPress />)
     .add('Grouped', () => <Grouped />)
+    .add('Horizontal - grouped', () => <HorizontalGrouped />)


### PR DESCRIPTION
Adds the ability to group stacked bar charts and normal bar charts (a stacked bar chart with only one key).  

To accomplish this I followed the example of the grouped bar chart but did not wind up extending StackedBarChart.  I had initially set out to extend, but wound up overriding everything in the end.

Stories were added for grouped stacked bars in vertical and horizontal configurations.