### PR TITLE
Feature/fork y axis issues

### DIFF
--- a/src/y-axis.js
+++ b/src/y-axis.js
@@ -100,7 +100,7 @@ class YAxis extends PureComponent {
                 >
                     {/*invisible text to allow for parent resizing*/}
                     <Text
-                        style={{ color: 'transparent', fontSize: svg.fontSize }}
+                        style={{ color: 'transparent', fontSize: svg.fontSize, paddingHorizontal: 2 }}
                     >
                         {longestValue}
                     </Text>

--- a/src/y-axis.js
+++ b/src/y-axis.js
@@ -67,7 +67,6 @@ class YAxis extends PureComponent {
         const { height, width } = this.state
 
         if (data.length === 0) {
-            return <View style={ style }/>
         }
 
         const values = data.map((item, index) => yAccessor({ item, index }))
@@ -75,8 +74,8 @@ class YAxis extends PureComponent {
         const extent = array.extent([ ...values, min, max ])
 
         const {
-            min = extent[ 0 ],
-            max = extent[ 1 ],
+            min = extent[0],
+            max = extent[1],
         } = this.props
 
         const domain = scale === d3Scale.scaleBand ? values : [ min, max ]
@@ -89,7 +88,7 @@ class YAxis extends PureComponent {
             y.ticks(numberOfTicks)
 
         const longestValue = ticks
-            .map((value, index) => formatLabel(value, index))
+            .map((value, index) => formatLabel(value, index, ticks.length))
             .reduce((prev, curr) => prev.toString().length > curr.toString().length ? prev : curr, 0)
 
         return (
@@ -129,7 +128,7 @@ class YAxis extends PureComponent {
                                             key={ index }
                                             y={ y(value) }
                                         >
-                                            {formatLabel(value, index)}
+                                            {formatLabel(value, index, ticks.length)}
                                         </SVGText>
                                     )
                                 })

--- a/src/y-axis.js
+++ b/src/y-axis.js
@@ -67,6 +67,7 @@ class YAxis extends PureComponent {
         const { height, width } = this.state
 
         if (data.length === 0) {
+            return <View style={ style } />
         }
 
         const values = data.map((item, index) => yAccessor({ item, index }))
@@ -125,7 +126,7 @@ class YAxis extends PureComponent {
                                             x={ '50%' }
                                             alignmentBaseline={ 'middle' }
                                             { ...svg }
-                                            key={ index }
+                                            key={ y(value) }
                                             y={ y(value) }
                                         >
                                             {formatLabel(value, index, ticks.length)}


### PR DESCRIPTION
Fixed 3 issues with the Y-Axis:

- Added horizontal padding to the Text element that sets the width.  Without this tick labels were getting cut off on the right.
- Added a parameter to `formatLabel` that informs the user of the number of ticks that have been generated since d3 does not honor the exact number sent to them based on the data.
- Changed the `key` prop of the  SVG `Text` elements to fix a problem with re-rendering when data is changed.  

Also, some formatting was done based off of the lint rules in place.