### PR TITLE
Fixed Android label issue

### DIFF
--- a/src/x-axis.js
+++ b/src/x-axis.js
@@ -98,11 +98,24 @@ class XAxis extends PureComponent {
 
         return (
             <View style={ style }>
-                <View style={{ flexGrow: 1 }} onLayout={ event => this._onLayout(event) }>
+                <View
+                    style={
+                        height && width
+                            ? {
+                                height,
+                                width,
+                            }
+                            : { flexGrow: 1 }
+                    }>
                     {/*invisible text to allow for parent resizing*/}
-                    <Text style={{ color: 'transparent', fontSize: svg.fontSize }}>
-                        {formatLabel(ticks[0], 0)}
-                    </Text>
+                    {!height &&
+                        !width && (
+                        <Text
+                            onLayout={ event => this._onLayout(event) }
+                            style={{ color: 'transparent', fontSize: svg.fontSize }}>
+                            {formatLabel(ticks[0], 0)}
+                        </Text>
+                    )}
                     {height > 0 &&
                         width > 0 && (
                         <Svg


### PR DESCRIPTION
The measurement text intended to be transparent was still showing on Android. Apparently Android doesn't like transparent text color. This fixes #248 of the parent library.