### PR TITLE
Added extra axis space

### DIFF
--- a/src/x-axis.js
+++ b/src/x-axis.js
@@ -17,9 +17,10 @@ class XAxis extends PureComponent {
                 layout: { width, height },
             },
         } = event
+        const { extraHeight } = this.props
 
         if (width !== this.state.width) {
-            this.setState({ width, height })
+            this.setState({ width, height: height + extraHeight })
         }
     }
 
@@ -178,6 +179,7 @@ XAxis.propTypes = {
     min: PropTypes.any,
     max: PropTypes.any,
     splitOnLineBreaks: PropTypes.bool,
+    extraHeight: PropTypes.number,
 }
 
 XAxis.defaultProps = {
@@ -189,6 +191,7 @@ XAxis.defaultProps = {
     scale: d3Scale.scaleLinear,
     formatLabel: value => value,
     splitOnLineBreaks: false,
+    extraHeight: 0,
 }
 
 export default XAxis

--- a/src/y-axis.js
+++ b/src/y-axis.js
@@ -14,7 +14,8 @@ class YAxis extends PureComponent {
 
     _onLayout(event) {
         const { nativeEvent: { layout: { height, width } } } = event
-        this.setState({ height, width })
+        const { extraWidth } = this.props
+        this.setState({ height, width: width + extraWidth })
     }
 
     getY(domain) {
@@ -172,6 +173,7 @@ YAxis.propTypes = {
     scale: PropTypes.func,
     spacingInner: PropTypes.number,
     spacingOuter: PropTypes.number,
+    extraWidth: PropTypes.number,
 }
 
 YAxis.defaultProps = {
@@ -183,6 +185,7 @@ YAxis.defaultProps = {
     scale: d3Scale.scaleLinear,
     formatLabel: value => value && value.toString(),
     yAccessor: ({ item }) => item,
+    extraWidth: 0,
 }
 
 export default YAxis


### PR DESCRIPTION
The main dimension of the axes are calculated purly based on the rendered text of a tick.  If the user wishes to transform or add a dy to the axis, it can cause clipping of the SVG text elements.  This change allows users to add extra space to the primary dimension of each axis.